### PR TITLE
ENTMQBR-2070 Add support for AIO in the broker image

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -50,6 +50,7 @@ packages:
     install:
         - hostname
         - systemd
+        - libaio
 
 modules:
       repositories:


### PR DESCRIPTION
To support AIO, libaio needs to be installed with the image.
To enable AIO, add '--aio' to your AMQ_EXTRA_ARGS container
environment variable.

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for other issues
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
