### PR TITLE
[CLOUD-3663] Adding ppc64le builds

### DIFF
--- a/overrides-j911-ga.yaml
+++ b/overrides-j911-ga.yaml
@@ -40,6 +40,7 @@ osbs:
         only:
           - s390x
           #- x86_64
+          - ppc64le
       compose:
         pulp_repos: true
         packages:


### PR DESCRIPTION
Signed-off-by: lysannef <lysannef@us.ibm.com>

Pull request with additions to support ppc64le builds alongside s390x.
https://issues.redhat.com/browse/CLOUD-3663