### PR TITLE
Updated ubi8 base image

### DIFF
--- a/overrides-j911-ga.yaml
+++ b/overrides-j911-ga.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
 
-from: "registry-proxy.engineering.redhat.com/rh-osbs/ubi8:8-released"
+from: "registry.redhat.io/ubi8/ubi:latest"
 name: &name "amq-broker-7/amq-broker-77-openj9-11-rhel8"
 version: &version "7.7"
 


### PR DESCRIPTION
`registry-proxy.engineering.redhat.com` has been deprecated and is not a permitted FROM source in OSBS.
Using `registry.redhat.io` instead.

- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for other issues
- [X] Attached commits represent units of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Rafiur Rashid rrashid@redhat.com
