### PR TITLE
Updated cct_module ref to 0.38.0-amq-multiarch

### DIFF
--- a/overrides-j911-ga.yaml
+++ b/overrides-j911-ga.yaml
@@ -20,11 +20,7 @@ modules:
           - name: cct_module
             git:
                  url: https://github.com/artemiscloud/cct_module.git
-                 ref: 0.38.0-amq
-          - name: cct_module_j9
-            git:
-                 url: https://github.com/jboss-openshift/cct_module.git
-                 ref: 0.39.0
+                 ref: 0.38.0-amq-multiarch
 
       install:
           - name: jboss.container.user


### PR DESCRIPTION
Updated cct_module ref that contains the openj9 module, eliminates the requirement to add cct_module_j9 module and enable to build openj9 image using latest cekit version.

- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for other issues
- [X] Attached commits represent units of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Rafiur Rashid rrashid@redhat.com
